### PR TITLE
Python2.7 dev

### DIFF
--- a/liegroups/_base.py
+++ b/liegroups/_base.py
@@ -1,4 +1,8 @@
-from abc import ABC, abstractmethod
+try:
+    from abc import ABC, abstractmethod
+except ImportError:  # support for python 2.7
+    from abc import ABCMeta as ABC
+    from abc import abstractmethod
 
 
 class LieGroupBase(ABC):

--- a/liegroups/_base.py
+++ b/liegroups/_base.py
@@ -135,7 +135,6 @@ class LieGroupBase(with_metaclass(ABC)):
         pass
 
 
-# class SpecialOrthogonalBase(LieGroupBase, ABC):
 class SpecialOrthogonalBase(LieGroupBase, with_metaclass(ABC)):
     """Common abstract _base class for Special Orthogonal groups SO(N)."""
     def __init__(self, mat):

--- a/liegroups/_base.py
+++ b/liegroups/_base.py
@@ -1,12 +1,14 @@
-try:
-    from abc import ABC, abstractmethod
-except ImportError:  # support for python 2.7
-    from abc import ABCMeta as ABC
-    from abc import abstractmethod
+from abc import ABCMeta as ABC
+from abc import abstractmethod
+
+# support for both python 2 and 3
+from future.utils import with_metaclass
 
 
-class LieGroupBase(ABC):
+# class LieGroupBase(ABC):
+class LieGroupBase(with_metaclass(ABC)):
     """Common abstract _base class for Lie groups."""
+
     @abstractmethod
     def __init__(self):
         pass
@@ -133,12 +135,12 @@ class LieGroupBase(ABC):
         pass
 
 
-class SpecialOrthogonalBase(LieGroupBase, ABC):
+# class SpecialOrthogonalBase(LieGroupBase, ABC):
+class SpecialOrthogonalBase(LieGroupBase, with_metaclass(ABC)):
     """Common abstract _base class for Special Orthogonal groups SO(N)."""
-
     def __init__(self, mat):
         """Create a transformation from a rotation matrix (unsafe, but faster)."""
-        super().__init__()
+        super(SpecialOrthogonalBase, self).__init__()
 
         self.mat = mat
         """Storage for the transformation matrix."""
@@ -156,12 +158,11 @@ class SpecialOrthogonalBase(LieGroupBase, ABC):
         self.mat = self.__class__.exp(phi).dot(self).mat
 
 
-class SpecialEuclideanBase(LieGroupBase, ABC):
+class SpecialEuclideanBase(LieGroupBase, with_metaclass(ABC)):
     """Common abstract _base class for Special Euclidean groups SE(N)."""
-
     def __init__(self, rot, trans):
         """Create a transformation from a translation and a rotation (unsafe, but faster)"""
-        super().__init__()
+        super(SpecialEuclideanBase, self).__init__()
 
         self.rot = rot
         """Storage for the rotation matrix."""

--- a/liegroups/torch/_base.py
+++ b/liegroups/torch/_base.py
@@ -169,7 +169,7 @@ class SpecialEuclideanBase(_base.SpecialEuclideanBase):
     """Implementation of methods common to SE(N) using PyTorch"""
 
     def __init__(self, rot, trans):
-        super().__init__(rot, trans)
+        super(SpecialEuclideanBase, self).__init__(rot, trans)
 
     def as_matrix(self):
         R = self.rot.as_matrix()


### PR DESCRIPTION
Modification to base classes for compatibility with python 2.7. On some systems, may require installing future (easy with pip).

For explanation of changes, see https://python-future.org/compatible_idioms.html, specifically the "Metaclasses" section.