### PR TITLE
Fixing device selection (cuda or cpu)

### DIFF
--- a/liegroups/torch/_base.py
+++ b/liegroups/torch/_base.py
@@ -112,11 +112,11 @@ class SOMatrixBase(_base.SOMatrixBase):
 
         # Determinants of each matrix in the batch should be 1
         det_check = utils.isclose(mat.__class__(
-            np.linalg.det(mat.detach().cpu().numpy())), 1.)
+            np.linalg.det(mat.detach().cpu().numpy())), 1.).to(mat.device)
 
         # The transpose of each matrix in the batch should be its inverse
         inv_check = utils.isclose(mat.transpose(2, 1).bmm(mat),
-                                  torch.eye(cls.dim, dtype=mat.dtype)).sum(dim=1).sum(dim=1) \
+                                  torch.eye(cls.dim, dtype=mat.dtype, device=mat.device)).sum(dim=1).sum(dim=1) \
             == cls.dim * cls.dim
 
         return shape_check & det_check & inv_check

--- a/liegroups/torch/so3.py
+++ b/liegroups/torch/so3.py
@@ -31,7 +31,7 @@ class SO3Matrix(_base.SOMatrixBase):
 
         if len(small_angle_inds) > 0:
             mat[small_angle_inds] = \
-                torch.eye(cls.dim, dtype=phi.dtype).expand_as(mat[small_angle_inds]) + \
+                torch.eye(cls.dim, dtype=phi.dtype, device=phi.device).expand_as(mat[small_angle_inds]) + \
                 cls.wedge(phi[small_angle_inds])
 
         # Otherwise...
@@ -47,7 +47,7 @@ class SO3Matrix(_base.SOMatrixBase):
             c = angle.cos().unsqueeze_(dim=1).unsqueeze_(
                 dim=2).expand_as(mat[large_angle_inds])
 
-            A = c * torch.eye(cls.dim, dtype=phi.dtype).unsqueeze_(dim=0).expand_as(
+            A = c * torch.eye(cls.dim, dtype=phi.dtype, device=phi.device).unsqueeze_(dim=0).expand_as(
                 mat[large_angle_inds])
             B = (1. - c) * utils.outer(axis, axis)
             C = s * cls.wedge(axis)
@@ -132,7 +132,7 @@ class SO3Matrix(_base.SOMatrixBase):
         small_angle_inds = small_angle_mask.nonzero().squeeze_(dim=1)
         if len(small_angle_inds) > 0:
             jac[small_angle_inds] = \
-                torch.eye(cls.dof, dtype=phi.dtype).expand_as(jac[small_angle_inds]) - \
+                torch.eye(cls.dof, dtype=phi.dtype, device=phi.device).expand_as(jac[small_angle_inds]) - \
                 0.5 * cls.wedge(phi[small_angle_inds])
 
         # Otherwise...
@@ -153,7 +153,7 @@ class SO3Matrix(_base.SOMatrixBase):
                 dim=2).expand_as(jac[large_angle_inds])
 
             A = hacha * \
-                torch.eye(cls.dof, dtype=phi.dtype).unsqueeze_(
+                torch.eye(cls.dof, dtype=phi.dtype, device=phi.device).unsqueeze_(
                     dim=0).expand_as(jac[large_angle_inds])
             B = (1. - hacha) * utils.outer(axis, axis)
             C = -ha * cls.wedge(axis)
@@ -179,7 +179,7 @@ class SO3Matrix(_base.SOMatrixBase):
         small_angle_inds = small_angle_mask.nonzero().squeeze_(dim=1)
         if len(small_angle_inds) > 0:
             jac[small_angle_inds] = \
-                torch.eye(cls.dof, dtype=phi.dtype).expand_as(jac[small_angle_inds]) + \
+                torch.eye(cls.dof, dtype=phi.dtype, device=phi.device).expand_as(jac[small_angle_inds]) + \
                 0.5 * cls.wedge(phi[small_angle_inds])
 
         # Otherwise...
@@ -195,7 +195,7 @@ class SO3Matrix(_base.SOMatrixBase):
 
             A = (s / angle).unsqueeze_(dim=1).unsqueeze_(
                 dim=2).expand_as(jac[large_angle_inds]) * \
-                torch.eye(cls.dof, dtype=phi.dtype).unsqueeze_(dim=0).expand_as(
+                torch.eye(cls.dof, dtype=phi.dtype, device=phi.device).unsqueeze_(dim=0).expand_as(
                 jac[large_angle_inds])
             B = (1. - s / angle).unsqueeze_(dim=1).unsqueeze_(
                 dim=2).expand_as(jac[large_angle_inds]) * \
@@ -228,7 +228,7 @@ class SO3Matrix(_base.SOMatrixBase):
         if len(small_angle_inds) > 0:
             phi[small_angle_inds, :] = \
                 self.vee(mat[small_angle_inds] -
-                         torch.eye(self.dim, dtype=mat.dtype).expand_as(mat[small_angle_inds]))
+                         torch.eye(self.dim, dtype=mat.dtype, device=mat.device).expand_as(mat[small_angle_inds]))
 
         # Otherwise...
         large_angle_mask = small_angle_mask.logical_not()

--- a/liegroups/torch/utils.py
+++ b/liegroups/torch/utils.py
@@ -44,6 +44,6 @@ def trace(mat):
         mat = mat.unsqueeze(dim=0)
 
     # Element-wise multiply by identity and take the sum
-    tr =  (torch.eye(mat.shape[1], dtype=mat.dtype) * mat).sum(dim=1).sum(dim=1)
+    tr =  (torch.eye(mat.shape[1], dtype=mat.dtype, device=mat.device) * mat).sum(dim=1).sum(dim=1)
     
     return tr.view(mat.shape[0])


### PR DESCRIPTION
The class methods in so3 creates new matrices (eye etc.) without taking the device selection taking into account. 
This patch should fix this by setting the right device directly while creating new matrices.