### PR TITLE
SE2 left jacobians

### DIFF
--- a/liegroups/numpy/se2.py
+++ b/liegroups/numpy/se2.py
@@ -87,15 +87,26 @@ class SE2Matrix(_base.SEMatrixBase):
 
         jac = np.zeros((cls.dof, cls.dof))
 
-        jac[0][0] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-        jac[0][1] = -(theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-        jac[0][2] = (theta*(x - 2*cos_theta*x - theta*y + cos_theta**2*x + sin_theta**2*x + cos_theta*theta*y - sin_theta*theta*x))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
-        jac[1][0] = (theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-        jac[1][1] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-        jac[1][2] = (theta*(y - 2*cos_theta*y + theta*x + cos_theta**2*y + sin_theta**2*y - cos_theta*theta*x - sin_theta*theta*y))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
-        jac[2][0] = 0
-        jac[2][1] = 0
-        jac[2][2] = 1
+        if theta_sq > 1e-15:
+            jac[0][0] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+            jac[0][1] = -(theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+            jac[0][2] = (theta*(x - 2*cos_theta*x - theta*y + cos_theta**2*x + sin_theta**2*x + cos_theta*theta*y - sin_theta*theta*x))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
+            jac[1][0] = (theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+            jac[1][1] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+            jac[1][2] = (theta*(y - 2*cos_theta*y + theta*x + cos_theta**2*y + sin_theta**2*y - cos_theta*theta*x - sin_theta*theta*y))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
+            jac[2][0] = 0
+            jac[2][1] = 0
+            jac[2][2] = 1
+        else:
+            jac[0][0] = -(96*(theta_sq - 6))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
+            jac[0][1] = -(24*theta*(theta_sq - 12))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
+            jac[0][2] = (4*(12*theta*x - 72*y + 12*theta_sq*y - 12*theta_sq*y + theta_sq*theta_sq*y + theta_sq*theta*x))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
+            jac[1][0] = (24*theta*(theta_sq - 12))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
+            jac[1][1] = -(96*(theta_sq - 6))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
+            jac[1][2] = (4*(72*x - 12*theta_sq*x + 12*theta*y + 12*theta_sq*x - theta_sq*theta_sq*x + theta_sq*theta*y))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
+            jac[2][0] = 0
+            jac[2][1] = 0
+            jac[2][2] = 1
 
         return jac
 

--- a/liegroups/numpy/se2.py
+++ b/liegroups/numpy/se2.py
@@ -76,30 +76,29 @@ class SE2Matrix(_base.SEMatrixBase):
         .. math::
             \\mathcal{J}^{-1}(\\boldsymbol{\\xi})
         """
-        x = xi[0]  # translation part
-        y = xi[1]  # translation part
-        theta = xi[2]  # rotation part
+        rho = xi[0:2]  # translation part
+        phi = xi[2]  # rotation part
 
-        cos_theta = np.cos(theta)
-        sin_theta = np.sin(theta)
-        theta_sq = theta * theta
+        cos_phi = np.cos(phi)
+        sin_phi = np.sin(phi)
+        phi_sq = phi * phi
 
         jac = np.zeros((cls.dof, cls.dof))
 
-        if theta_sq > 1e-15:
-            jac[0][0] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-            jac[0][1] = -(theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-            jac[0][2] = (theta*(x - 2*cos_theta*x - theta*y + cos_theta**2*x + sin_theta**2*x + cos_theta*theta*y - sin_theta*theta*x))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
-            jac[1][0] = (theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-            jac[1][1] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
-            jac[1][2] = (theta*(y - 2*cos_theta*y + theta*x + cos_theta**2*y + sin_theta**2*y - cos_theta*theta*x - sin_theta*theta*y))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
+        if phi_sq > 1e-15:
+            jac[0][0] = (sin_phi*phi)/(cos_phi**2 - 2*cos_phi + sin_phi**2 + 1)
+            jac[0][1] = -(phi*(cos_phi - 1))/(cos_phi**2 - 2*cos_phi + sin_phi**2 + 1)
+            jac[0][2] = (phi*(rho[0] - 2*cos_phi*rho[0] - phi*rho[1] + cos_phi**2*rho[0] + sin_phi**2*rho[0] + cos_phi*phi*rho[1] - sin_phi*phi*rho[0]))/(phi_sq*(cos_phi**2 - 2*cos_phi + sin_phi**2 + 1))
+            jac[1][0] = (phi*(cos_phi - 1))/(cos_phi**2 - 2*cos_phi + sin_phi**2 + 1)
+            jac[1][1] = (sin_phi*phi)/(cos_phi**2 - 2*cos_phi + sin_phi**2 + 1)
+            jac[1][2] = (phi*(rho[1] - 2*cos_phi*rho[1] + phi*rho[0] + cos_phi**2*rho[1] + sin_phi**2*rho[1] - cos_phi*phi*rho[0] - sin_phi*phi*rho[1]))/(phi_sq*(cos_phi**2 - 2*cos_phi + sin_phi**2 + 1))
         else:
-            jac[0][0] = -(96*(theta_sq - 6))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
-            jac[0][1] = -(24*theta*(theta_sq - 12))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
-            jac[0][2] = (4*(12*theta*x - 72*y + 12*theta_sq*y - 12*theta_sq*y + theta_sq*theta_sq*y + theta_sq*theta*x))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
-            jac[1][0] = (24*theta*(theta_sq - 12))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
-            jac[1][1] = -(96*(theta_sq - 6))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
-            jac[1][2] = (4*(72*x - 12*theta_sq*x + 12*theta*y + 12*theta_sq*x - theta_sq*theta_sq*x + theta_sq*theta*y))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
+            jac[0][0] = -(96*(phi_sq - 6))/(phi_sq**2*phi_sq + 16*phi_sq**2 - 24*phi_sq*phi_sq - 192*phi_sq + 144*phi_sq + 576)
+            jac[0][1] = -(24*phi*(phi_sq - 12))/(phi_sq**2*phi_sq + 16*phi_sq**2 - 24*phi_sq*phi_sq - 192*phi_sq + 144*phi_sq + 576)
+            jac[0][2] = (4*(12*phi*rho[0] - 72*rho[1] + 12*phi_sq*rho[1] - 12*phi_sq*rho[1] + phi_sq*phi_sq*rho[1] + phi_sq*phi*rho[0]))/(phi_sq**2*phi_sq + 16*phi_sq**2 - 24*phi_sq*phi_sq - 192*phi_sq + 144*phi_sq + 576)
+            jac[1][0] = (24*phi*(phi_sq - 12))/(phi_sq**2*phi_sq + 16*phi_sq**2 - 24*phi_sq*phi_sq - 192*phi_sq + 144*phi_sq + 576)
+            jac[1][1] = -(96*(phi_sq - 6))/(phi_sq**2*phi_sq + 16*phi_sq**2 - 24*phi_sq*phi_sq - 192*phi_sq + 144*phi_sq + 576)
+            jac[1][2] = (4*(72*rho[0] - 12*phi_sq*rho[0] + 12*phi*rho[1] + 12*phi_sq*rho[0] - phi_sq*phi_sq*rho[0] + phi_sq*phi*rho[1]))/(phi_sq**2*phi_sq + 16*phi_sq**2 - 24*phi_sq*phi_sq - 192*phi_sq + 144*phi_sq + 576)
         
         jac[2][0] = 0
         jac[2][1] = 0
@@ -117,20 +116,19 @@ class SE2Matrix(_base.SEMatrixBase):
 
         # based on https://github.com/artivis/manif/blob/6f2c1cd3e050a2a232cc5f6c4fb0d33b74f08701/include/manif/impl/se2/SE2Tangent_base.h
 
-        x = xi[0]  # translation part
-        y = xi[1]  # translation part
-        theta = xi[2]  # rotation part
+        rho = xi[0:2]  # translation part
+        phi = xi[2]  # rotation part
 
-        cos_theta = np.cos(theta)
-        sin_theta = np.sin(theta)
-        theta_sq = theta * theta
+        cos_phi = np.cos(phi)
+        sin_phi = np.sin(phi)
+        phi_sq = phi * phi
 
-        if theta_sq < 1e-15:
-            A = 1 - 1./6. * theta_sq
-            B = 0.5 * theta - 1./24. * theta * theta_sq
+        if phi_sq < 1e-15:
+            A = 1 - 1./6. * phi_sq
+            B = 0.5 * phi - 1./24. * phi * phi_sq
         else:
-            A = sin_theta / theta
-            B = (1 - cos_theta) / theta
+            A = sin_phi / phi
+            B = (1 - cos_phi) / phi
 
         jac = np.zeros((cls.dof, cls.dof))
         jac[0][0] = A
@@ -138,12 +136,12 @@ class SE2Matrix(_base.SEMatrixBase):
         jac[1][0] = B
         jac[1][1] = A
 
-        if theta_sq < 1e-15:
-            jac[0][2] = y / 2. + theta * x / 6.
-            jac[1][2] = -x / 2. + theta * y / 6.
+        if phi_sq < 1e-15:
+            jac[0][2] = rho[1] / 2. + phi * rho[0] / 6.
+            jac[1][2] = -rho[0] / 2. + phi * rho[1] / 6.
         else:
-            jac[0][2] = ( y + theta*x - y*cos_theta - x*sin_theta)/theta_sq
-            jac[1][2] = (-x + theta*y + x*cos_theta - y*sin_theta)/theta_sq
+            jac[0][2] = ( rho[1] + phi*rho[0] - rho[1]*cos_phi - rho[0]*sin_phi)/phi_sq
+            jac[1][2] = (-rho[0] + phi*rho[1] + rho[0]*cos_phi - rho[1]*sin_phi)/phi_sq
 
         jac[2][2] = 1
 

--- a/liegroups/numpy/se2.py
+++ b/liegroups/numpy/se2.py
@@ -76,10 +76,9 @@ class SE2Matrix(_base.SEMatrixBase):
         .. math::
             \\mathcal{J}^{-1}(\\boldsymbol{\\xi})
         """
-        se2 = cls.exp(xi)
-        theta = se2.rot.to_angle()
-        x = se2.trans[0]
-        y = se2.trans[1]
+        x = xi[0]  # translation part
+        y = xi[1]  # translation part
+        theta = xi[2]  # rotation part
 
         cos_theta = np.cos(theta)
         sin_theta = np.sin(theta)
@@ -118,10 +117,9 @@ class SE2Matrix(_base.SEMatrixBase):
 
         # based on https://github.com/artivis/manif/blob/6f2c1cd3e050a2a232cc5f6c4fb0d33b74f08701/include/manif/impl/se2/SE2Tangent_base.h
 
-        se2 = cls.exp(xi)
-        theta = se2.rot.to_angle()
-        x = se2.trans[0]
-        y = se2.trans[1]
+        x = xi[0]  # translation part
+        y = xi[1]  # translation part
+        theta = xi[2]  # rotation part
 
         cos_theta = np.cos(theta)
         sin_theta = np.sin(theta)

--- a/liegroups/numpy/se2.py
+++ b/liegroups/numpy/se2.py
@@ -76,7 +76,28 @@ class SE2Matrix(_base.SEMatrixBase):
         .. math::
             \\mathcal{J}^{-1}(\\boldsymbol{\\xi})
         """
-        raise NotImplementedError
+        se2 = cls.exp(xi)
+        theta = se2.rot.to_angle()
+        x = se2.trans[0]
+        y = se2.trans[1]
+
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        theta_sq = theta * theta
+
+        jac = np.zeros((cls.dof, cls.dof))
+
+        jac[0][0] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+        jac[0][1] = -(theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+        jac[0][2] = (theta*(x - 2*cos_theta*x - theta*y + cos_theta**2*x + sin_theta**2*x + cos_theta*theta*y - sin_theta*theta*x))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
+        jac[1][0] = (theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+        jac[1][1] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
+        jac[1][2] = (theta*(y - 2*cos_theta*y + theta*x + cos_theta**2*y + sin_theta**2*y - cos_theta*theta*x - sin_theta*theta*y))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
+        jac[2][0] = 0
+        jac[2][1] = 0
+        jac[2][2] = 1
+
+        return jac
 
     @classmethod
     def left_jacobian(cls, xi):

--- a/liegroups/numpy/se2.py
+++ b/liegroups/numpy/se2.py
@@ -42,7 +42,7 @@ class SE2Matrix(_base.SEMatrixBase):
             \\end{bmatrix}
             \\in \\mathbb{R}^{3 \\times 3}
         """
-        rot_part = self.rot.as_matrix
+        rot_part = self.rot.as_matrix()
         trans_part = np.array([self.trans[1], -self.trans[0]]).reshape((2, 1))
         return np.vstack([np.hstack([rot_part, trans_part]),
                           [0, 0, 1]])

--- a/liegroups/numpy/se2.py
+++ b/liegroups/numpy/se2.py
@@ -94,9 +94,6 @@ class SE2Matrix(_base.SEMatrixBase):
             jac[1][0] = (theta*(cos_theta - 1))/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
             jac[1][1] = (sin_theta*theta)/(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1)
             jac[1][2] = (theta*(y - 2*cos_theta*y + theta*x + cos_theta**2*y + sin_theta**2*y - cos_theta*theta*x - sin_theta*theta*y))/(theta_sq*(cos_theta**2 - 2*cos_theta + sin_theta**2 + 1))
-            jac[2][0] = 0
-            jac[2][1] = 0
-            jac[2][2] = 1
         else:
             jac[0][0] = -(96*(theta_sq - 6))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
             jac[0][1] = -(24*theta*(theta_sq - 12))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
@@ -104,9 +101,10 @@ class SE2Matrix(_base.SEMatrixBase):
             jac[1][0] = (24*theta*(theta_sq - 12))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
             jac[1][1] = -(96*(theta_sq - 6))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
             jac[1][2] = (4*(72*x - 12*theta_sq*x + 12*theta*y + 12*theta_sq*x - theta_sq*theta_sq*x + theta_sq*theta*y))/(theta_sq**2*theta_sq + 16*theta_sq**2 - 24*theta_sq*theta_sq - 192*theta_sq + 144*theta_sq + 576)
-            jac[2][0] = 0
-            jac[2][1] = 0
-            jac[2][2] = 1
+        
+        jac[2][0] = 0
+        jac[2][1] = 0
+        jac[2][2] = 1
 
         return jac
 

--- a/liegroups/numpy/se2.py
+++ b/liegroups/numpy/se2.py
@@ -117,6 +117,8 @@ class SE2Matrix(_base.SEMatrixBase):
             jac[0][2] = ( y + theta*x - y*cos_theta - x*sin_theta)/theta_sq
             jac[1][2] = (-x + theta*y + x*cos_theta - y*sin_theta)/theta_sq
 
+        jac[2][2] = 1
+
         return jac
 
     def log(self):

--- a/liegroups/torch/_base.py
+++ b/liegroups/torch/_base.py
@@ -112,11 +112,11 @@ class SOMatrixBase(_base.SOMatrixBase):
 
         # Determinants of each matrix in the batch should be 1
         det_check = utils.isclose(mat.__class__(
-            np.linalg.det(mat.detach().cpu().numpy())), 1.)
+            np.linalg.det(mat.detach().cpu().numpy())).to(mat.device), 1.)
 
         # The transpose of each matrix in the batch should be its inverse
         inv_check = utils.isclose(mat.transpose(2, 1).bmm(mat),
-                                  torch.eye(cls.dim, dtype=mat.dtype)).sum(dim=1).sum(dim=1) \
+                                  torch.eye(cls.dim, dtype=mat.dtype, device=mat.device)).sum(dim=1).sum(dim=1) \
             == cls.dim * cls.dim
 
         return shape_check & det_check & inv_check

--- a/liegroups/torch/se2.py
+++ b/liegroups/torch/se2.py
@@ -82,7 +82,7 @@ class SE2Matrix(_base.SEMatrixBase):
         large_angle_mask = small_angle_mask.logical_not()
         large_angle_inds = large_angle_mask.nonzero().squeeze_(dim=1)
 
-        jac = torch.zeros((xi.shape[0], cls.dof, cls.dof))
+        jac = torch.zeros((xi.shape[0], cls.dof, cls.dof)).to(xi.device)
 
         jac[small_angle_inds, 0, 0] = -(96*(theta_sq[small_angle_inds] - 6))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
         jac[small_angle_inds, 0, 1] = -(24*theta[small_angle_inds]*(theta_sq[small_angle_inds] - 12))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
@@ -128,7 +128,7 @@ class SE2Matrix(_base.SEMatrixBase):
         large_angle_mask = small_angle_mask.logical_not()
         large_angle_inds = large_angle_mask.nonzero().squeeze_(dim=1)
 
-        jac = torch.zeros((xi.shape[0], cls.dof, cls.dof))
+        jac = torch.zeros((xi.shape[0], cls.dof, cls.dof)).to(xi.device)
 
         jac[small_angle_inds, 0, 0] = 1 - 1./6. * theta_sq[small_angle_inds]
         jac[small_angle_inds, 0, 1] = -(0.5 * theta[small_angle_inds] - 1./24. * theta[small_angle_inds] * theta_sq[small_angle_inds])

--- a/liegroups/torch/se2.py
+++ b/liegroups/torch/se2.py
@@ -64,7 +64,46 @@ class SE2Matrix(_base.SEMatrixBase):
 
     @classmethod
     def left_jacobian(cls, xi):
-        raise NotImplementedError
+
+        x = xi[:, 0]  # translation part
+        y = xi[:, 2]  # translation part
+        theta = xi[:, 2]  # rotation part
+
+        cos_theta = torch.cos(theta)
+        sin_theta = torch.sin(theta)
+        theta_sq = theta * theta
+
+        small_angle_mask = utils.isclose(theta_sq, 0.)
+        small_angle_inds = small_angle_mask.nonzero().squeeze_(dim=1)
+
+        large_angle_mask = small_angle_mask.logical_not()
+        large_angle_inds = large_angle_mask.nonzero().squeeze_(dim=1)
+
+        jac = torch.zeros((xi.shape[0], cls.dof, cls.dof))
+
+        jac[small_angle_inds, 0, 0] = 1 - 1./6. * theta_sq[small_angle_inds]
+        jac[large_angle_inds, 0, 0] = sin_theta[large_angle_inds] / theta[large_angle_inds]
+
+        jac[small_angle_inds, 0, 1] = -(0.5 * theta[small_angle_inds] - 1./24. * theta[small_angle_inds] * theta_sq[small_angle_inds])
+        jac[large_angle_inds, 0, 1] = -(1 - cos_theta[large_angle_inds]) / theta[large_angle_inds]
+
+        jac[small_angle_inds, 0, 2] = y[small_angle_inds] / 2. + theta[small_angle_inds] * x[small_angle_inds] / 6.
+        jac[large_angle_inds, 0, 2] = ( y[large_angle_inds] + theta[large_angle_inds]*x[large_angle_inds] - y[large_angle_inds]*cos_theta[large_angle_inds] - x[large_angle_inds]*sin_theta[large_angle_inds])/theta_sq[large_angle_inds]
+
+        jac[small_angle_inds, 1, 0] = 0.5 * theta[small_angle_inds] - 1./24. * theta[small_angle_inds] * theta_sq[small_angle_inds]
+        jac[large_angle_inds, 1, 0] = (1 - cos_theta[large_angle_inds]) / theta[large_angle_inds]
+
+        jac[small_angle_inds, 1, 1] = 1 - 1./6. * theta_sq[small_angle_inds]
+        jac[large_angle_inds, 1, 1] = sin_theta[large_angle_inds] / theta[large_angle_inds]
+
+        jac[small_angle_inds, 1, 2] = -x[small_angle_inds] / 2. + theta[small_angle_inds] * y[small_angle_inds] / 6.
+        jac[large_angle_inds, 1, 2] = (-x[large_angle_inds] + theta[large_angle_inds]*y[large_angle_inds] + x[large_angle_inds]*cos_theta[large_angle_inds] - y[large_angle_inds]*sin_theta[large_angle_inds])/theta_sq[large_angle_inds]
+
+        jac[:, 2, 0] = 0
+        jac[:, 2, 1] = 0
+        jac[:, 2, 2] = 1
+
+        return jac
 
     def log(self):
         phi = self.rot.log()

--- a/liegroups/torch/se2.py
+++ b/liegroups/torch/se2.py
@@ -68,15 +68,14 @@ class SE2Matrix(_base.SEMatrixBase):
             raise ValueError(
                 "xi must have shape ({},) or (N,{})".format(cls.dof, cls.dof))
 
-        x = xi[:, 0]  # translation part
-        y = xi[:, 1]  # translation part
-        theta = xi[:, 2]  # rotation part
+        rho = xi[:, 0:2]  # translation part
+        phi = xi[:, 2]  # rotation part
 
-        cos_theta = torch.cos(theta)
-        sin_theta = torch.sin(theta)
-        theta_sq = theta * theta
+        cos_phi = torch.cos(phi)
+        sin_phi = torch.sin(phi)
+        phi_sq = phi * phi
 
-        small_angle_mask = utils.isclose(theta_sq, 0.)
+        small_angle_mask = utils.isclose(phi_sq, 0.)
         small_angle_inds = small_angle_mask.nonzero().squeeze_(dim=1)
 
         large_angle_mask = small_angle_mask.logical_not()
@@ -84,19 +83,19 @@ class SE2Matrix(_base.SEMatrixBase):
 
         jac = torch.zeros((xi.shape[0], cls.dof, cls.dof)).to(xi.device)
 
-        jac[small_angle_inds, 0, 0] = -(96*(theta_sq[small_angle_inds] - 6))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
-        jac[small_angle_inds, 0, 1] = -(24*theta[small_angle_inds]*(theta_sq[small_angle_inds] - 12))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
-        jac[small_angle_inds, 0, 2] = (4*(12*theta[small_angle_inds]*x[small_angle_inds] - 72*y[small_angle_inds] + 12*theta_sq[small_angle_inds]*y[small_angle_inds] - 12*theta_sq[small_angle_inds]*y[small_angle_inds] + theta_sq[small_angle_inds]*theta_sq[small_angle_inds]*y[small_angle_inds] + theta_sq[small_angle_inds]*theta[small_angle_inds]*x[small_angle_inds]))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
-        jac[small_angle_inds, 1, 0] = (24*theta[small_angle_inds]*(theta_sq[small_angle_inds] - 12))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
-        jac[small_angle_inds, 1, 1] = -(96*(theta_sq[small_angle_inds] - 6))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
-        jac[small_angle_inds, 1, 2] = (4*(72*x[small_angle_inds] - 12*theta_sq[small_angle_inds]*x[small_angle_inds] + 12*theta[small_angle_inds]*y[small_angle_inds] + 12*theta_sq[small_angle_inds]*x[small_angle_inds] - theta_sq[small_angle_inds]*theta_sq[small_angle_inds]*x[small_angle_inds] + theta_sq[small_angle_inds]*theta[small_angle_inds]*y[small_angle_inds]))/(theta_sq[small_angle_inds]**2*theta_sq[small_angle_inds] + 16*theta_sq[small_angle_inds]**2 - 24*theta_sq[small_angle_inds]*theta_sq[small_angle_inds] - 192*theta_sq[small_angle_inds] + 144*theta_sq[small_angle_inds] + 576)
+        jac[small_angle_inds, 0, 0] = -(96*(phi_sq[small_angle_inds] - 6))/(phi_sq[small_angle_inds]**2*phi_sq[small_angle_inds] + 16*phi_sq[small_angle_inds]**2 - 24*phi_sq[small_angle_inds]*phi_sq[small_angle_inds] - 192*phi_sq[small_angle_inds] + 144*phi_sq[small_angle_inds] + 576)
+        jac[small_angle_inds, 0, 1] = -(24*phi[small_angle_inds]*(phi_sq[small_angle_inds] - 12))/(phi_sq[small_angle_inds]**2*phi_sq[small_angle_inds] + 16*phi_sq[small_angle_inds]**2 - 24*phi_sq[small_angle_inds]*phi_sq[small_angle_inds] - 192*phi_sq[small_angle_inds] + 144*phi_sq[small_angle_inds] + 576)
+        jac[small_angle_inds, 0, 2] = (4*(12*phi[small_angle_inds]*rho[small_angle_inds,0] - 72*rho[small_angle_inds,1] + 12*phi_sq[small_angle_inds]*rho[small_angle_inds,1] - 12*phi_sq[small_angle_inds]*rho[small_angle_inds,1] + phi_sq[small_angle_inds]*phi_sq[small_angle_inds]*rho[small_angle_inds,1] + phi_sq[small_angle_inds]*phi[small_angle_inds]*rho[small_angle_inds,0]))/(phi_sq[small_angle_inds]**2*phi_sq[small_angle_inds] + 16*phi_sq[small_angle_inds]**2 - 24*phi_sq[small_angle_inds]*phi_sq[small_angle_inds] - 192*phi_sq[small_angle_inds] + 144*phi_sq[small_angle_inds] + 576)
+        jac[small_angle_inds, 1, 0] = (24*phi[small_angle_inds]*(phi_sq[small_angle_inds] - 12))/(phi_sq[small_angle_inds]**2*phi_sq[small_angle_inds] + 16*phi_sq[small_angle_inds]**2 - 24*phi_sq[small_angle_inds]*phi_sq[small_angle_inds] - 192*phi_sq[small_angle_inds] + 144*phi_sq[small_angle_inds] + 576)
+        jac[small_angle_inds, 1, 1] = -(96*(phi_sq[small_angle_inds] - 6))/(phi_sq[small_angle_inds]**2*phi_sq[small_angle_inds] + 16*phi_sq[small_angle_inds]**2 - 24*phi_sq[small_angle_inds]*phi_sq[small_angle_inds] - 192*phi_sq[small_angle_inds] + 144*phi_sq[small_angle_inds] + 576)
+        jac[small_angle_inds, 1, 2] = (4*(72*rho[small_angle_inds,0] - 12*phi_sq[small_angle_inds]*rho[small_angle_inds,0] + 12*phi[small_angle_inds]*rho[small_angle_inds,1] + 12*phi_sq[small_angle_inds]*rho[small_angle_inds,0] - phi_sq[small_angle_inds]*phi_sq[small_angle_inds]*rho[small_angle_inds,0] + phi_sq[small_angle_inds]*phi[small_angle_inds]*rho[small_angle_inds,1]))/(phi_sq[small_angle_inds]**2*phi_sq[small_angle_inds] + 16*phi_sq[small_angle_inds]**2 - 24*phi_sq[small_angle_inds]*phi_sq[small_angle_inds] - 192*phi_sq[small_angle_inds] + 144*phi_sq[small_angle_inds] + 576)
 
-        jac[large_angle_inds, 0, 0] = (sin_theta[large_angle_inds]*theta[large_angle_inds])/(cos_theta[large_angle_inds]**2 - 2*cos_theta[large_angle_inds] + sin_theta[large_angle_inds]**2 + 1)
-        jac[large_angle_inds, 0, 1] = -(theta[large_angle_inds]*(cos_theta[large_angle_inds] - 1))/(cos_theta[large_angle_inds]**2 - 2*cos_theta[large_angle_inds] + sin_theta[large_angle_inds]**2 + 1)
-        jac[large_angle_inds, 0, 2] = (theta[large_angle_inds]*(x[large_angle_inds] - 2*cos_theta[large_angle_inds]*x[large_angle_inds] - theta[large_angle_inds]*y[large_angle_inds] + cos_theta[large_angle_inds]**2*x[large_angle_inds] + sin_theta[large_angle_inds]**2*x[large_angle_inds] + cos_theta[large_angle_inds]*theta[large_angle_inds]*y[large_angle_inds] - sin_theta[large_angle_inds]*theta[large_angle_inds]*x[large_angle_inds]))/(theta_sq[large_angle_inds]*(cos_theta[large_angle_inds]**2 - 2*cos_theta[large_angle_inds] + sin_theta[large_angle_inds]**2 + 1))
-        jac[large_angle_inds, 1, 0] = (theta[large_angle_inds]*(cos_theta[large_angle_inds] - 1))/(cos_theta[large_angle_inds]**2 - 2*cos_theta[large_angle_inds] + sin_theta[large_angle_inds]**2 + 1)
-        jac[large_angle_inds, 1, 1] = (sin_theta[large_angle_inds]*theta[large_angle_inds])/(cos_theta[large_angle_inds]**2 - 2*cos_theta[large_angle_inds] + sin_theta[large_angle_inds]**2 + 1)
-        jac[large_angle_inds, 1, 2] = (theta[large_angle_inds]*(y[large_angle_inds] - 2*cos_theta[large_angle_inds]*y[large_angle_inds] + theta[large_angle_inds]*x[large_angle_inds] + cos_theta[large_angle_inds]**2*y[large_angle_inds] + sin_theta[large_angle_inds]**2*y[large_angle_inds] - cos_theta[large_angle_inds]*theta[large_angle_inds]*x[large_angle_inds] - sin_theta[large_angle_inds]*theta[large_angle_inds]*y[large_angle_inds]))/(theta_sq[large_angle_inds]*(cos_theta[large_angle_inds]**2 - 2*cos_theta[large_angle_inds] + sin_theta[large_angle_inds]**2 + 1))
+        jac[large_angle_inds, 0, 0] = (sin_phi[large_angle_inds]*phi[large_angle_inds])/(cos_phi[large_angle_inds]**2 - 2*cos_phi[large_angle_inds] + sin_phi[large_angle_inds]**2 + 1)
+        jac[large_angle_inds, 0, 1] = -(phi[large_angle_inds]*(cos_phi[large_angle_inds] - 1))/(cos_phi[large_angle_inds]**2 - 2*cos_phi[large_angle_inds] + sin_phi[large_angle_inds]**2 + 1)
+        jac[large_angle_inds, 0, 2] = (phi[large_angle_inds]*(rho[large_angle_inds,0] - 2*cos_phi[large_angle_inds]*rho[large_angle_inds,0] - phi[large_angle_inds]*rho[large_angle_inds,1] + cos_phi[large_angle_inds]**2*rho[large_angle_inds,0] + sin_phi[large_angle_inds]**2*rho[large_angle_inds,0] + cos_phi[large_angle_inds]*phi[large_angle_inds]*rho[large_angle_inds,1] - sin_phi[large_angle_inds]*phi[large_angle_inds]*rho[large_angle_inds,0]))/(phi_sq[large_angle_inds]*(cos_phi[large_angle_inds]**2 - 2*cos_phi[large_angle_inds] + sin_phi[large_angle_inds]**2 + 1))
+        jac[large_angle_inds, 1, 0] = (phi[large_angle_inds]*(cos_phi[large_angle_inds] - 1))/(cos_phi[large_angle_inds]**2 - 2*cos_phi[large_angle_inds] + sin_phi[large_angle_inds]**2 + 1)
+        jac[large_angle_inds, 1, 1] = (sin_phi[large_angle_inds]*phi[large_angle_inds])/(cos_phi[large_angle_inds]**2 - 2*cos_phi[large_angle_inds] + sin_phi[large_angle_inds]**2 + 1)
+        jac[large_angle_inds, 1, 2] = (phi[large_angle_inds]*(rho[large_angle_inds,1] - 2*cos_phi[large_angle_inds]*rho[large_angle_inds,1] + phi[large_angle_inds]*rho[large_angle_inds,0] + cos_phi[large_angle_inds]**2*rho[large_angle_inds,1] + sin_phi[large_angle_inds]**2*rho[large_angle_inds,1] - cos_phi[large_angle_inds]*phi[large_angle_inds]*rho[large_angle_inds,0] - sin_phi[large_angle_inds]*phi[large_angle_inds]*rho[large_angle_inds,1]))/(phi_sq[large_angle_inds]*(cos_phi[large_angle_inds]**2 - 2*cos_phi[large_angle_inds] + sin_phi[large_angle_inds]**2 + 1))
         
         jac[:, 2, 0] = 0
         jac[:, 2, 1] = 0
@@ -114,15 +113,14 @@ class SE2Matrix(_base.SEMatrixBase):
             raise ValueError(
                 "xi must have shape ({},) or (N,{})".format(cls.dof, cls.dof))
 
-        x = xi[:, 0]  # translation part
-        y = xi[:, 1]  # translation part
-        theta = xi[:, 2]  # rotation part
+        rho = xi[:, 0:2]  # translation part
+        phi = xi[:, 2]  # rotation part
 
-        cos_theta = torch.cos(theta)
-        sin_theta = torch.sin(theta)
-        theta_sq = theta * theta
+        cos_phi = torch.cos(phi)
+        sin_phi = torch.sin(phi)
+        phi_sq = phi * phi
 
-        small_angle_mask = utils.isclose(theta_sq, 0.)
+        small_angle_mask = utils.isclose(phi_sq, 0.)
         small_angle_inds = small_angle_mask.nonzero().squeeze_(dim=1)
 
         large_angle_mask = small_angle_mask.logical_not()
@@ -130,19 +128,19 @@ class SE2Matrix(_base.SEMatrixBase):
 
         jac = torch.zeros((xi.shape[0], cls.dof, cls.dof)).to(xi.device)
 
-        jac[small_angle_inds, 0, 0] = 1 - 1./6. * theta_sq[small_angle_inds]
-        jac[small_angle_inds, 0, 1] = -(0.5 * theta[small_angle_inds] - 1./24. * theta[small_angle_inds] * theta_sq[small_angle_inds])
-        jac[small_angle_inds, 0, 2] = y[small_angle_inds] / 2. + theta[small_angle_inds] * x[small_angle_inds] / 6.
-        jac[small_angle_inds, 1, 0] = 0.5 * theta[small_angle_inds] - 1./24. * theta[small_angle_inds] * theta_sq[small_angle_inds]
-        jac[small_angle_inds, 1, 1] = 1 - 1./6. * theta_sq[small_angle_inds]
-        jac[small_angle_inds, 1, 2] = -x[small_angle_inds] / 2. + theta[small_angle_inds] * y[small_angle_inds] / 6.
+        jac[small_angle_inds, 0, 0] = 1 - 1./6. * phi_sq[small_angle_inds]
+        jac[small_angle_inds, 0, 1] = -(0.5 * phi[small_angle_inds] - 1./24. * phi[small_angle_inds] * phi_sq[small_angle_inds])
+        jac[small_angle_inds, 0, 2] = rho[small_angle_inds,1] / 2. + phi[small_angle_inds] * rho[small_angle_inds,0] / 6.
+        jac[small_angle_inds, 1, 0] = 0.5 * phi[small_angle_inds] - 1./24. * phi[small_angle_inds] * phi_sq[small_angle_inds]
+        jac[small_angle_inds, 1, 1] = 1 - 1./6. * phi_sq[small_angle_inds]
+        jac[small_angle_inds, 1, 2] = -rho[small_angle_inds,0] / 2. + phi[small_angle_inds] * rho[small_angle_inds,1] / 6.
 
-        jac[large_angle_inds, 0, 0] = sin_theta[large_angle_inds] / theta[large_angle_inds]
-        jac[large_angle_inds, 0, 1] = -(1 - cos_theta[large_angle_inds]) / theta[large_angle_inds]
-        jac[large_angle_inds, 0, 2] = ( y[large_angle_inds] + theta[large_angle_inds]*x[large_angle_inds] - y[large_angle_inds]*cos_theta[large_angle_inds] - x[large_angle_inds]*sin_theta[large_angle_inds])/theta_sq[large_angle_inds]
-        jac[large_angle_inds, 1, 0] = (1 - cos_theta[large_angle_inds]) / theta[large_angle_inds]
-        jac[large_angle_inds, 1, 1] = sin_theta[large_angle_inds] / theta[large_angle_inds]
-        jac[large_angle_inds, 1, 2] = (-x[large_angle_inds] + theta[large_angle_inds]*y[large_angle_inds] + x[large_angle_inds]*cos_theta[large_angle_inds] - y[large_angle_inds]*sin_theta[large_angle_inds])/theta_sq[large_angle_inds]
+        jac[large_angle_inds, 0, 0] = sin_phi[large_angle_inds] / phi[large_angle_inds]
+        jac[large_angle_inds, 0, 1] = -(1 - cos_phi[large_angle_inds]) / phi[large_angle_inds]
+        jac[large_angle_inds, 0, 2] = ( rho[large_angle_inds,1] + phi[large_angle_inds]*rho[large_angle_inds,0] - rho[large_angle_inds,1]*cos_phi[large_angle_inds] - rho[large_angle_inds,0]*sin_phi[large_angle_inds])/phi_sq[large_angle_inds]
+        jac[large_angle_inds, 1, 0] = (1 - cos_phi[large_angle_inds]) / phi[large_angle_inds]
+        jac[large_angle_inds, 1, 1] = sin_phi[large_angle_inds] / phi[large_angle_inds]
+        jac[large_angle_inds, 1, 2] = (-rho[large_angle_inds,0] + phi[large_angle_inds]*rho[large_angle_inds,1] + rho[large_angle_inds,0]*cos_phi[large_angle_inds] - rho[large_angle_inds,1]*sin_phi[large_angle_inds])/phi_sq[large_angle_inds]
 
         jac[:, 2, 0] = 0
         jac[:, 2, 1] = 0

--- a/liegroups/torch/so2.py
+++ b/liegroups/torch/so2.py
@@ -42,14 +42,14 @@ class SO2Matrix(_base.SOMatrixBase):
         if phi.dim() < 1:
             phi = phi.unsqueeze(dim=0)
 
-        jac = phi.__class__(phi.shape[0], cls.dim, cls.dim)
+        jac = phi.__class__(phi.shape[0], cls.dim, cls.dim).to(phi.device)
 
         # Near phi==0, use first order Taylor expansion
         small_angle_mask = utils.isclose(phi, 0.)
         small_angle_inds = small_angle_mask.nonzero().squeeze_(dim=1)
 
         if len(small_angle_inds) > 0:
-            jac[small_angle_inds] = torch.eye(cls.dim).expand(
+            jac[small_angle_inds] = torch.eye(cls.dim).to(phi.device).expand(
                 len(small_angle_inds), cls.dim, cls.dim) \
                 - 0.5 * cls.wedge(phi[small_angle_inds])
 
@@ -68,9 +68,9 @@ class SO2Matrix(_base.SOMatrixBase):
                 dim=2).expand_as(jac[large_angle_inds])
 
             A = hacha * \
-                torch.eye(cls.dim).unsqueeze_(
+                torch.eye(cls.dim).to(phi.device).unsqueeze_(
                     dim=0).expand_as(jac[large_angle_inds])
-            B = -ha * cls.wedge(phi.__class__([1.]))
+            B = -ha * cls.wedge(phi.__class__([1.]).to(phi.device))
 
             jac[large_angle_inds] = A + B
 
@@ -82,14 +82,14 @@ class SO2Matrix(_base.SOMatrixBase):
         if phi.dim() < 1:
             phi = phi.unsqueeze(dim=0)
 
-        jac = phi.__class__(phi.shape[0], cls.dim, cls.dim)
+        jac = phi.__class__(phi.shape[0], cls.dim, cls.dim).to(phi.device)
 
         # Near phi==0, use first order Taylor expansion
         small_angle_mask = utils.isclose(phi, 0.)
         small_angle_inds = small_angle_mask.nonzero().squeeze_(dim=1)
 
         if len(small_angle_inds) > 0:
-            jac[small_angle_inds] = torch.eye(cls.dim).expand(
+            jac[small_angle_inds] = torch.eye(cls.dim).to(phi.device).expand(
                 len(small_angle_inds), cls.dim, cls.dim) \
                 + 0.5 * cls.wedge(phi[small_angle_inds])
 
@@ -104,11 +104,11 @@ class SO2Matrix(_base.SOMatrixBase):
 
             A = (s / angle).unsqueeze_(dim=1).unsqueeze_(
                 dim=2).expand_as(jac[large_angle_inds]) * \
-                torch.eye(cls.dim).unsqueeze_(dim=0).expand_as(
+                torch.eye(cls.dim).to(phi.device).unsqueeze_(dim=0).expand_as(
                 jac[large_angle_inds])
-            B = ((1. - c) / angle).unsqueeze_(dim=1).unsqueeze_(
+            B = ((1.0 - c) / angle).unsqueeze_(dim=1).unsqueeze_(
                 dim=2).expand_as(jac[large_angle_inds]) * \
-                cls.wedge(phi.__class__([1.]))
+                cls.wedge(phi.__class__([1.]).to(phi.device))
 
             jac[large_angle_inds] = A + B
 

--- a/tests/numpy/test_se2_numpy.py
+++ b/tests/numpy/test_se2_numpy.py
@@ -103,3 +103,16 @@ def test_transform_vectorized():
     assert np.allclose(Tpt2, Tpts12[1])
     assert np.allclose(Tpt3, Tpts34[0])
     assert np.allclose(Tpt4, Tpts34[1])
+
+def test_left_jacobian():
+    xi1 = [1, 2, 3]
+    assert np.allclose(
+        SE2.left_jacobian(xi1).dot(SE2.inv_left_jacobian(xi1)),
+        np.identity(3)
+    )
+
+    xi2 = [0, 0, 0]
+    assert np.allclose(
+        SE2.left_jacobian(xi2).dot(SE2.inv_left_jacobian(xi2)),
+        np.identity(3)
+    )

--- a/tests/torch/test_se2_torch.py
+++ b/tests/torch/test_se2_torch.py
@@ -309,3 +309,25 @@ def test_adjoint_batch():
     T = SE2.exp(0.1 * torch.Tensor([[1, 2, 3],
                                     [4, 5, 6]]))
     assert T.adjoint().shape == (2, 3, 3)
+
+def test_left_jacobian():
+    xi1 = torch.Tensor([1, 2, 3])
+    assert utils.allclose(
+        torch.mm(SE2.left_jacobian(xi1), SE2.inv_left_jacobian(xi1)),
+        torch.eye(3)
+    )
+
+    xi2 = torch.Tensor([0, 0, 0])
+    assert utils.allclose(
+        torch.mm(SE2.left_jacobian(xi2), SE2.inv_left_jacobian(xi2)),
+        torch.eye(3)
+    )
+
+
+def test_left_jacobian_batch():
+    xis = torch.Tensor([[1, 2, 3],
+                        [0, 0, 0]])
+    assert utils.allclose(
+        SE2.left_jacobian(xis).bmm(SE2.inv_left_jacobian(xis)),
+        torch.eye(3).unsqueeze_(dim=0).expand(2, 3, 3)
+    )


### PR DESCRIPTION
Implemented the SE(2) group jacobian (and inverse) in numpy and torch.
These did not seem to be covered in Barfoot and so the reference for the solution implemented in this PR is a Lie theory described in https://arxiv.org/pdf/1812.01537.pdf.
Specifically, I ported the left jacobian implementation from the C++ code here: https://github.com/artivis/manif/blob/6f2c1cd3e050a2a232cc5f6c4fb0d33b74f08701/include/manif/impl/se2/SE2Tangent_base.h
The paper does not provide a closed form solution for the inverse left jacobian, so I used MATLAB's symbolic toolbox to arrive at one - for both the general and small angle cases.
This has all been unit tested in the same style as SE(3) cases.
Incidentally, when testing this on GPU (torch version), I ran into a few problems with the SO2/base interfaces. This PR thus includes a few fixes along those lines.